### PR TITLE
[SYSTEMDS-3668] Fix ultra-sparse tsmm for CSR sparse blocks

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixMult.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixMult.java
@@ -451,10 +451,13 @@ public class LibMatrixMult
 		matrixMultTransposeSelf(m1, m1t, ret, leftTranspose, 0, ret.rlen);
 
 		//post-processing
-		if(copyToLowerTriangle){
+		if(copyToLowerTriangle) {
 			long nnz = copyUpperToLowerTriangle(ret);
 			ret.setNonZeros(nnz);
 			ret.examSparsity();
+		}
+		else {
+			ret.recomputeNonZeros();
 		}
 		
 		//System.out.println("TSMM ("+m1.isInSparseFormat()+","+m1.getNumRows()+","+m1.getNumColumns()+","+m1.getNonZeros()+","+leftTranspose+") in "+time.stop());
@@ -2600,8 +2603,9 @@ public class LibMatrixMult
 				int[] bix = b.indexes(aixk);
 				double[] bvals = b.values(aixk);
 				//sparse updates for ultra-sparse output
-				for(int k2 = bpos2; k2<bpos+blen; k2++)
+				for(int k2 = bpos+bpos2; k2<bpos+blen; k2++) {
 					c.add(i, bix[k2], aval*bvals[k2]);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
There were flaky component tests, which originated from the shared matrix blocks being converted from MCSR to CSR and then the new ultra-sparse tsmm failing due to incorrect index handling. This patch generalizes the tsmm implementation for all sparse blocks.